### PR TITLE
Fix request params and typo in `pickPocket` skill id

### DIFF
--- a/src/habiticalib/lib.py
+++ b/src/habiticalib/lib.py
@@ -849,7 +849,7 @@ class Habitica:
         if target_id:
             params.update({"targetId": str(target_id)})
         return HabiticaUserResponse.from_json(
-            await self._request("post", url=url, json=params),
+            await self._request("post", url=url, params=params),
         )
 
     async def toggle_sleep(

--- a/src/habiticalib/types.py
+++ b/src/habiticalib/types.py
@@ -1194,7 +1194,7 @@ class Skill(StrEnum):
     VALOROUS_PRESENCE = "valorousPresence"
     INTIMIDATING_GAZE = "intimidate"
     # Rogue skills
-    PICKPOCKET = "Pickpocket"
+    PICKPOCKET = "pickPocket"
     BACKSTAB = "backStab"
     TOOLS_OF_THE_TRADE = "toolsOfTrade"
     STEALTH = "stealth"


### PR DESCRIPTION
- `targetId` was submitted as json instead of url params
- fixed typo in id of `Skill.PICKPOCKET` 